### PR TITLE
Enable luabind error checking

### DIFF
--- a/io.github.cortex_command_community.Cortex-Command-Community-Project.yml
+++ b/io.github.cortex_command_community.Cortex-Command-Community-Project.yml
@@ -60,6 +60,8 @@ modules:
         # FIXME: all files below should be removed on the next release
       - type: patch
         path: runner.patch
+      - type: patch
+        path: luabind-error-check.patch
       - type: file
         dest-filename: cccp.svg
         url: https://raw.githubusercontent.com/cortex-command-community/Cortex-Command-Community-Project/f64e3a0177723854220acdc60b37650809087920/Resources/io.github.cortex_command_community.Cortex-Command-Community-Project.svg

--- a/luabind-error-check.patch
+++ b/luabind-error-check.patch
@@ -1,0 +1,15 @@
+diff --git a/external/sources/luabind-0.7.1/meson.build b/external/sources/luabind-0.7.1/meson.build
+index 850d386ef..7ca5460ad 100644
+--- a/external/sources/luabind-0.7.1/meson.build
++++ b/external/sources/luabind-0.7.1/meson.build
+@@ -20,12 +20,8 @@ elif cxx.get_argument_syntax() == 'msvc'
+   cpp_options = ['cpp_std=vc++20']
+ endif
+ 
+-if (not get_option('debug')) or get_option('debug_type') == 'release'
+-  luabind_args += ['-DLUABIND_NO_ERROR_CHECKING=1']
+-endif
+-
+ luabind = static_library('luabind071', luabind_src, dependencies: luabind_dependencies, include_directories:luabind_include, cpp_args:cpp_args+ luabind_args, override_options: ['warning_level=0']+ cpp_options)
+ 
+ luabind_dep = declare_dependency(link_with: luabind, dependencies: deps, include_directories: luabind_include, compile_args: luabind_args)


### PR DESCRIPTION
Was causing a bunch of crashes and isn't disabled in the Windows build anyways which caused a ton of confusion.